### PR TITLE
Support a fallback action policy

### DIFF
--- a/contracts/DataTypes.sol
+++ b/contracts/DataTypes.sol
@@ -164,6 +164,8 @@ uint256 constant ERC7579_MODULE_TYPE_POLICY = 7;
 // selector does not have a set action policy, then the fallback will be used if
 // enabled.
 ActionId constant FALLBACK_ACTIONID = ActionId.wrap(bytes32(uint256(1)));
+address constant FALLBACK_TARGET_FLAG = address(1);
+bytes4 constant FALLBACK_TARGET_SELECTOR_FLAG = 0x00000001;
 
 // A unique ValidationData value to retry a policy check with the FALLBACK_ACTIONID.
 ValidationData constant RETRY_WITH_FALLBACK = ValidationData.wrap(uint256(0x50FFBAAD));

--- a/contracts/DataTypes.sol
+++ b/contracts/DataTypes.sol
@@ -159,6 +159,26 @@ uint256 constant ERC7579_MODULE_TYPE_HOOK = 4;
 // the module type is tbd, but for now we use 7, until a new module type via ERC7579 extension process is defined
 uint256 constant ERC7579_MODULE_TYPE_POLICY = 7;
 
+// ActionId for a fallback action policy. This id will be used if both action
+// target and selector are set to 1. During validation if the current target and
+// selector does not have a set action policy, then the fallback will be used if
+// enabled.
+ActionId constant FALLBACK_ACTIONID = ActionId.wrap(bytes32(uint256(1)));
+
+// A unique ValidationData value to retry a policy check with the FALLBACK_ACTIONID.
+ValidationData constant RETRY_WITH_FALLBACK = ValidationData.wrap(uint256(0x50FFBAAD));
+
+using { validationDataEq as == } for ValidationData global;
+using { validationDataNeq as != } for ValidationData global;
+
+function validationDataEq(ValidationData uid1, ValidationData uid2) pure returns (bool) {
+    return ValidationData.unwrap(uid1) == ValidationData.unwrap(uid2);
+}
+
+function validationDataNeq(ValidationData uid1, ValidationData uid2) pure returns (bool) {
+    return ValidationData.unwrap(uid1) != ValidationData.unwrap(uid2);
+}
+
 using { permissionIdEq as == } for PermissionId global;
 using { permissionIdNeq as != } for PermissionId global;
 

--- a/contracts/lib/IdLib.sol
+++ b/contracts/lib/IdLib.sol
@@ -9,7 +9,7 @@ library IdLib {
     }
 
     function toActionId(address target, bytes4 functionSelector) internal pure returns (ActionId actionId) {
-        if (target == address(1) && functionSelector == 0x00000001) {
+        if (target == FALLBACK_TARGET_FLAG && functionSelector == FALLBACK_TARGET_SELECTOR_FLAG) {
             actionId = FALLBACK_ACTIONID;
         } else {
             actionId = ActionId.wrap(keccak256(abi.encodePacked(target, functionSelector)));

--- a/contracts/lib/IdLib.sol
+++ b/contracts/lib/IdLib.sol
@@ -9,7 +9,11 @@ library IdLib {
     }
 
     function toActionId(address target, bytes4 functionSelector) internal pure returns (ActionId actionId) {
-        actionId = ActionId.wrap(keccak256(abi.encodePacked(target, functionSelector)));
+        if (target == address(1) && functionSelector == 0x00000001) {
+            actionId = FALLBACK_ACTIONID;
+        } else {
+            actionId = ActionId.wrap(keccak256(abi.encodePacked(target, functionSelector)));
+        }
     }
 
     function toActionPolicyId(

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -19,7 +19,7 @@ import "contracts/DataTypes.sol";
 import { EncodeLib } from "contracts/lib/EncodeLib.sol";
 import { YesSigner } from "./mock/YesSigner.sol";
 import { MockTarget } from "./mock/MockTarget.sol";
-// import { YesPolicy } from "./mock/YesPolicy.sol";
+import { YesPolicy } from "contracts/external/policies/SudoPolicy.sol";
 import { MockRegistry } from "./mock/MockRegistry.sol";
 import { SimpleSigner } from "./mock/SimpleSigner.sol";
 import { SimpleGasPolicy } from "./mock/SimpleGasPolicy.sol";
@@ -32,8 +32,6 @@ import { UserOperationBuilder } from "test/mock/erc7679/UserOpBuilder.sol";
 import { ModeLib, ModeCode as ExecutionMode } from "erc7579/lib/ModeLib.sol";
 import { HashLib } from "contracts/lib/HashLib.sol";
 import { TestHashLib } from "test/utils/TestHashLib.sol";
-
-import { YesPolicy } from "contracts/external/policies/SudoPolicy.sol";
 
 import "forge-std/console2.sol";
 

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -19,7 +19,7 @@ import "contracts/DataTypes.sol";
 import { EncodeLib } from "contracts/lib/EncodeLib.sol";
 import { YesSigner } from "./mock/YesSigner.sol";
 import { MockTarget } from "./mock/MockTarget.sol";
-import { YesPolicy } from "./mock/YesPolicy.sol";
+// import { YesPolicy } from "./mock/YesPolicy.sol";
 import { MockRegistry } from "./mock/MockRegistry.sol";
 import { SimpleSigner } from "./mock/SimpleSigner.sol";
 import { SimpleGasPolicy } from "./mock/SimpleGasPolicy.sol";
@@ -32,6 +32,8 @@ import { UserOperationBuilder } from "test/mock/erc7679/UserOpBuilder.sol";
 import { ModeLib, ModeCode as ExecutionMode } from "erc7579/lib/ModeLib.sol";
 import { HashLib } from "contracts/lib/HashLib.sol";
 import { TestHashLib } from "test/utils/TestHashLib.sol";
+
+import { YesPolicy } from "contracts/external/policies/SudoPolicy.sol";
 
 import "forge-std/console2.sol";
 

--- a/test/unit/SudoSession.t.sol
+++ b/test/unit/SudoSession.t.sol
@@ -28,8 +28,8 @@ contract SudoSessionTest is BaseTest {
 
         ActionData[] memory actionDatas = new ActionData[](1);
         actionDatas[0] = ActionData({
-            actionTarget: address(1),
-            actionTargetSelector: bytes4(0x00000001),
+            actionTarget: FALLBACK_TARGET_FLAG,
+            actionTargetSelector: FALLBACK_TARGET_SELECTOR_FLAG,
             actionPolicies: policyDatas
         });
 

--- a/test/unit/SudoSession.t.sol
+++ b/test/unit/SudoSession.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.25;
+
+import "../Base.t.sol";
+
+import "solmate/test/utils/mocks/MockERC20.sol";
+import "forge-std/interfaces/IERC20.sol";
+
+contract SudoSessionTest is BaseTest {
+    using ModuleKitHelpers for *;
+    using ModuleKitUserOp for *;
+
+    MockERC20 token1;
+    MockERC20 token2;
+    PermissionId permissionId;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        token1 = new MockERC20("MockToken1", "MTK1", 18);
+        token2 = new MockERC20("MockToken2", "MTK2", 18);
+
+        token1.mint(instance.account, 100 ether);
+        token2.mint(instance.account, 100 ether);
+
+        PolicyData[] memory policyDatas = new PolicyData[](1);
+        policyDatas[0] = PolicyData({ policy: address(yesPolicy), initData: "" });
+
+        ActionData[] memory actionDatas = new ActionData[](1);
+        actionDatas[0] = ActionData({
+            actionTarget: address(1),
+            actionTargetSelector: bytes4(0x00000001),
+            actionPolicies: policyDatas
+        });
+
+        Session memory session = Session({
+            sessionValidator: ISessionValidator(address(yesSigner)),
+            salt: keccak256("salt"),
+            sessionValidatorInitData: "mockInitData",
+            userOpPolicies: _getEmptyPolicyDatas(address(yesPolicy)),
+            erc7739Policies: _getEmptyERC7739Data("mockContent", _getEmptyPolicyDatas(address(yesPolicy))),
+            actions: actionDatas
+        });
+
+        permissionId = smartSession.getPermissionId(session);
+
+        Session[] memory enableSessionsArray = new Session[](1);
+        enableSessionsArray[0] = session;
+
+        vm.prank(instance.account);
+        smartSession.enableSessions(enableSessionsArray);
+    }
+
+    function test_transferWithSession() public {
+        address recipient = makeAddr("recipient");
+
+        // Token 1 ok
+        UserOpData memory userOpData = instance.getExecOps({
+            target: address(token1),
+            value: 0,
+            callData: abi.encodeCall(IERC20.transfer, (recipient, 1 ether)),
+            txValidator: address(smartSession)
+        });
+
+        userOpData.userOp.signature = EncodeLib.encodeUse({ permissionId: permissionId, sig: hex"4141414141" });
+        userOpData.execUserOps();
+        assertEq(token1.balanceOf(recipient), 1 ether);
+
+        // Token 2 ok
+        userOpData = instance.getExecOps({
+            target: address(token2),
+            value: 0,
+            callData: abi.encodeCall(IERC20.transfer, (recipient, 100 ether)),
+            txValidator: address(smartSession)
+        });
+
+        userOpData.userOp.signature = EncodeLib.encodeUse({ permissionId: permissionId, sig: hex"4141414141" });
+        userOpData.execUserOps();
+        assertEq(token2.balanceOf(recipient), 100 ether);
+    }
+}


### PR DESCRIPTION
This PR enables a session to have a fallback action policy if target and selector are set to `1`. This would allow multiple targets and selectors without a defined policy to be validated with a fallback. This in turn enables use cases such as a sudo session.