### PR TITLE
Use correct ActionId in fallback check

### DIFF
--- a/contracts/lib/PolicyLib.sol
+++ b/contracts/lib/PolicyLib.sol
@@ -181,7 +181,8 @@ library PolicyLib {
                 userOp: userOp,
                 permissionId: permissionId,
                 callOnIPolicy: abi.encodeCall(
-                    IActionPolicy.checkAction, (permissionId.toConfigId(actionId), userOp.sender, target, value, callData)
+                    IActionPolicy.checkAction,
+                    (permissionId.toConfigId(FALLBACK_ACTIONID), userOp.sender, target, value, callData)
                 ),
                 minPolicies: minPolicies
             });


### PR DESCRIPTION
In a fallback check (see #1), `configId` must be calculated from `FALLBACK_ACTIONID`.